### PR TITLE
fix the error "Object has been destroyed" when nyaovim exists

### DIFF
--- a/main/browser-config.ts
+++ b/main/browser-config.ts
@@ -69,9 +69,10 @@ export default class BrowserConfig {
         if (this.window_state === null) {
             return null;
         }
-        win.once('closed', () => {
+        win.on('resize', () => {
             this.window_state.saveState(win);
         });
+
         if (this.window_state.isMaximized) {
             win.maximize();
         }


### PR DESCRIPTION
close https://github.com/rhysd/NyaoVim/issues/62

### What was a problem?
electron shows error "Object has been destroyed" when nyaovim exists

### How this PR fixes the problem?
nyaovim should not access BrowserWindow object in `closed` event.
I save the window state in `resize` event instead.

### Check lists (check `x` in `[ ]` of list items)

- [x ] Coding style (if any code was modified)
- [x ] Confirmed
  - OS: {OSX 10.11}
  - `nvim` version: {0.1.5}

### Additional Comments (if any)

{Please write here}


