### PR TITLE
 support "copy to system clipboard"

### DIFF
--- a/main/menu.ts
+++ b/main/menu.ts
@@ -37,12 +37,16 @@ export default function setMenu() {
                 {
                     label: 'Copy',
                     accelerator: 'CmdOrCtrl+C',
-                    role: 'copy',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:copy');
+                    },
                 },
                 {
                     label: 'Paste',
                     accelerator: 'CmdOrCtrl+V',
-                    role: 'paste',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:paste');
+                    },
                 },
                 {
                     label: 'Select All',


### PR DESCRIPTION
<!-- Thank you for your contribution to NyaoVim! Please replace {Please write here} with your description -->
Close https://github.com/rhysd/NyaoVim/issues/61

### What was a problem?
As described in #61 

### How this PR fixes the problem?

When a user presses `cmd+c` or `cmd+v`, `NyaoVim` will execute the corresponding vi command instead of the default Electron copy & paste actions.

### Check lists (check `x` in `[ ]` of list items)

- [x] Coding style (if any code was modified)
- [x] Confirmed
  - OS: {OSX 10.11}
  - `nvim` version: {0.1.5}

### Additional Comments (if any)

{Please write here}


