### PR TITLE
Polymer property binding doesn't need `$=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example, below configures font face and font size by `font` and `font-size` 
 ```html
 <neovim-editor
     id="nyaovim-editor"
-    argv$="[[argv]]"
+    argv="[[argv]]"
     font-size="14"
     font="Ricty,monospace"
     line-height="1.5"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ If you don't want to add `nvim`'s directory path to `$PATH`, please specify the 
 ```html
 <neovim-editor
     id="nyaovim-editor"
-    argv$="[[argv]]"
+    argv="[[argv]]"
     nvim-cmd="/custom/path/to/nvim"
 ></neovim-editor>
 ```

--- a/main/main.ts
+++ b/main/main.ts
@@ -64,7 +64,7 @@ function prepareDefaultNyaovimrc() {
     </style>
 
     <!-- Component tags here -->
-    <neovim-editor id="nyaovim-editor" argv$="[[argv]]" font="monospace"></neovim-editor>
+    <neovim-editor id="nyaovim-editor" arg="[[argv]]" font="monospace"></neovim-editor>
   </template>
 </dom-module>
 `;

--- a/main/main.ts
+++ b/main/main.ts
@@ -64,7 +64,7 @@ function prepareDefaultNyaovimrc() {
     </style>
 
     <!-- Component tags here -->
-    <neovim-editor id="nyaovim-editor" arg="[[argv]]" font="monospace"></neovim-editor>
+    <neovim-editor id="nyaovim-editor" argv="[[argv]]" font="monospace"></neovim-editor>
   </template>
 </dom-module>
 `;


### PR DESCRIPTION

### What was a problem?

`neovim-editor` doesn't receive any argv from `nyaovim-app`. `:let g:nyaovim_version` shows `undefined variable`.

### How this PR fixes the problem?

`$=` is for attribute binding, not property binding. I changed it to `=` in my own `nyaovimrc.html` and then `:let g:nyaovim_version` worked.

### Check lists (check `x` in `[ ]` of list items)

- [x] Coding style (if any code was modified)
- [x] Confirmed

### Additional Comments (if any)
close https://github.com/rhysd/NyaoVim/issues/65