### PR TITLE
Make edit menu work

### DIFF
--- a/main/menu.ts
+++ b/main/menu.ts
@@ -32,7 +32,9 @@ export default function setMenu() {
                 {
                     label: 'Cut',
                     accelerator: 'CmdOrCtrl+X',
-                    role: 'cut',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:cut');
+                    },
                 },
                 {
                     label: 'Copy',

--- a/main/menu.ts
+++ b/main/menu.ts
@@ -37,12 +37,16 @@ export default function setMenu() {
                 {
                     label: 'Copy',
                     accelerator: 'CmdOrCtrl+C',
-                    role: 'copy',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:copy');
+                    },
                 },
                 {
                     label: 'Paste',
                     accelerator: 'CmdOrCtrl+V',
-                    role: 'paste',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:paste');
+                    },
                 },
                 {
                     label: 'Select All',

--- a/main/menu.ts
+++ b/main/menu.ts
@@ -19,12 +19,21 @@ export default function setMenu() {
                 {
                     label: 'Undo',
                     accelerator: 'CmdOrCtrl+Z',
-                    role: 'undo',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:exec-commands', [
+                            'undo'
+                        ]);
+
+                    },
                 },
                 {
                     label: 'Redo',
                     accelerator: 'Shift+CmdOrCtrl+Z',
-                    role: 'redo',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:exec-commands', [
+                            'redo'
+                        ]);
+                    },
                 },
                 {
                     type: 'separator',

--- a/main/menu.ts
+++ b/main/menu.ts
@@ -51,7 +51,9 @@ export default function setMenu() {
                 {
                     label: 'Select All',
                     accelerator: 'CmdOrCtrl+A',
-                    role: 'selectall',
+                    click: (_: any, win: Electron.BrowserWindow) => {
+                        win.webContents.send('nyaovim:select-all');
+                    },
                 },
             ],
         },

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -209,6 +209,32 @@ Polymer({
                 });
             });
 
+            ipc.on('nyaovim:cut', (_: Electron.IpcRendererEvent) => {
+                // get current vim mode
+                var m = client.commandOutput('echo mode()');
+                m.then(value => {
+                    //  mode() returns a strange '\n' at the beginning, why?
+                    value = value.trim();
+                    if (value.length > 0) {
+                        const ch = value[0];
+
+                        if (ch == 'v'  // visual mode
+                            || ch == 'V' // visual line mode
+                            || (ch == '^' && value[1] == 'V') // visual block mode
+                           ) {
+                            const command = '"+x';
+                            client.input(command);
+                        } else {
+                            // other modes
+                            const webContents = ThisBrowserWindow.webContents;
+
+                            // execute the default cut command
+                            webContents.cut();
+                        }
+                    }
+                });
+            });
+
             ipc.on('nyaovim:paste', (_: Electron.IpcRendererEvent) => {
                 // get current vim mode
                 var m = client.commandOutput('echo mode()');

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -188,6 +188,27 @@ Polymer({
                 });
             });
 
+            ipc.on('nyaovim:select-all', (_: Electron.IpcRendererEvent) => {
+                // get current vim mode
+                var m = client.commandOutput('echo mode()');
+                m.then(value => {
+                    //  mode() returns a strange '\n' at the beginning, why?
+                    value = value.trim();
+                    if (value.length > 0) {
+                        const ch = value[0];
+
+                        if (ch == 'n') {
+                            const command = 'ggVG';
+                            client.input(command);
+                        } else {
+                            // switch to normal mode first
+                            const command = '<esc>ggVG';
+                            client.input(command);
+                        }
+                    }
+                });
+            });
+
             ipc.on('nyaovim:paste', (_: Electron.IpcRendererEvent) => {
                 // get current vim mode
                 var m = client.commandOutput('echo mode()');

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -212,6 +212,11 @@ Polymer({
                                 // normal mode
                                 const command = '"+p';
                                 client.input(command);
+                            } else if (ch == 'i') {
+                                // insert mode
+                                // gp will move cursor to the last of pasted content
+                                const command = '<esc>"+gpi';
+                                client.input(command);
                             } else {
                                 // other modes
                                 const webContents = ThisBrowserWindow.webContents;


### PR DESCRIPTION
### What was a problem?

- support system clipboard (#61)
- fix paste breaks format (#38)
- make undo and redo in edit work

### How this PR fixes the problem?

When a user presses cmd+c, v, a, x, or z, NyaoVim will execute the corresponding vi command instead of the default Electron actions.

### Check lists (check `x` in `[ ]` of list items)

- [x] Coding style (if any code was modified)
- [x] Confirmed
  - OS: {OSX 10.11}
  - `nvim` version: {0.1.5}

### Additional Comments (if any)

close #61
close #38