### PR TITLE
fix ctrl-v paste doesn't work in command line mode

### DIFF
--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -253,6 +253,12 @@ Polymer({
                         // insert mode
                         // gp will move cursor to the last of pasted content
                         command = '<esc>"+gpi';
+                    } else {
+                         // other modes (e.g. command line mode)
+                         const webContents = ThisBrowserWindow.webContents;
+
+                         // execute the default paste command
+                         webContents.paste();
                     }
                     if (command) {
                         client.input(command);

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -253,12 +253,9 @@ Polymer({
                         // insert mode
                         // gp will move cursor to the last of pasted content
                         command = '<esc>"+gpi';
-                    } else {
-                         // other modes (e.g. command line mode)
-                         const webContents = ThisBrowserWindow.webContents;
-
-                         // execute the default paste command
-                         webContents.paste();
+                    } else if (ch === 'c') {
+                         // command line mode
+                        command = '<c-r>+';
                     }
                     if (command) {
                         client.input(command);


### PR DESCRIPTION
<!-- Thank you for your contribution to NyaoVim! Please replace {Please write here} with your description -->
ctrl-v (and cmd-v) doesn't paste anything in command line mode

### How this PR fixes the problem?

Use electron's default paste command to paste from clipboard

### Check lists (check `x` in `[ ]` of list items)

- [x] Coding style (if any code was modified)
- [x] Confirmed
  - OS: {OSX 10.11}
  - `nvim` version: {0.1.5}

