### PR TITLE
 support double click to open a file

### DIFF
--- a/main/main.ts
+++ b/main/main.ts
@@ -140,6 +140,15 @@ app.on('open-url', (e: Event, u: string) => {
     e.preventDefault();
     shell.openExternal(u);
 });
+app.once('will-finish-launching', function() {
+    // we use once here because only the first open-file event might be missed by nyaovim-app
+    app.once('open-file', (e: Event, p: string) => {
+        // open-file event might be sent before ready event is emitted
+        // put it in argv to let nyaovim-app to pick it up later
+        process.argv.push(p);
+        e.preventDefault();
+    });
+});
 
 app.once(
     'ready',

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -1,6 +1,6 @@
 import {NeovimElement} from 'neovim-component';
 import {remote, shell, ipcRenderer as ipc} from 'electron';
-import {join} from 'path';
+import {join, basename} from 'path';
 import {readdirSync} from 'fs';
 import {Nvim, RPCValue} from 'promised-neovim-client';
 

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -222,12 +222,20 @@ Polymer({
         argv: {
             type: Array,
             value: function() {
+                let electron_argc =  1; // the first argument of standalone distribution is the application path
+                if (remote.process.argv.length > 1
+                    && 'electron' === basename(remote.process.argv[0]).toLowerCase()) {
+                    // Note: First and second arguments are related to Electron
+                    // the second argument of Electron is the script name (main.js)
+                    electron_argc = 2;
+                }
+
                 // Note:
                 // First and second arguments are related to Electron
                 // XXX:
                 // Spectron additionally passes many specific arguments to process and 'nvim' process
                 // will fail because of them.  As a workaround, we stupidly ignore arguments on E2E tests.
-                const a = process.env.NYAOVIM_E2E_TEST_RUNNING ? [] : remote.process.argv.slice(2);
+                const a = process.env.NYAOVIM_E2E_TEST_RUNNING ? [] : remote.process.argv.slice(electron_argc);
                 a.push(
                     '--cmd', `let\ g:nyaovim_version="${remote.app.getVersion()}"`,
                     '--cmd', `set\ rtp+=${join(__dirname, '..', 'runtime').replace(' ', '\ ')}`,

--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -222,9 +222,12 @@ Polymer({
         argv: {
             type: Array,
             value: function() {
+
+                // handle the arguments of the standalone Nyaovim.app
                 let electron_argc =  1; // the first argument of standalone distribution is the application path
-                if (remote.process.argv.length > 1
-                    && 'electron' === basename(remote.process.argv[0]).toLowerCase()) {
+                if (remote.process.platform !== 'darwin' // if not OSX, we assume it is not standalone
+                    || (remote.process.argv.length > 1
+                    && 'electron' === basename(remote.process.argv[0]).toLowerCase())) {
                     // Note: First and second arguments are related to Electron
                     // the second argument of Electron is the script name (main.js)
                     electron_argc = 2;


### PR DESCRIPTION
### What was a problem?

nyaovim doesn't open the file when a user double-clicks it

### How this PR fixes the problem?

`open-file` event might be sent before ready event is emitted
put the path in argv to let nyaovim-app to pick it up later

### Check lists (check `x` in `[ ]` of list items)

- [x] Coding style (if any code was modified)
- [x] Confirmed
  - OS: OSX 10.11
  - `nvim` version: NVIM v0.1.6-232-g5a61ff1