### PR TITLE
fix paste command in insert mode

### DIFF
--- a/renderer/nyaovim-app.ts
+++ b/renderer/nyaovim-app.ts
@@ -209,7 +209,7 @@ function prepareIpc(client: Nvim) {
             } else if (ch === 'i') {
                 // insert mode
                 // gp will move cursor to the last of pasted content
-                command = '<C-o>"+gp';
+                command = '"+gp';
             } else if (ch === 'c') {
                     // command line mode
                 command = '<C-r>+';


### PR DESCRIPTION
### What was a problem?
Close https://github.com/rhysd/NyaoVim/issues/103

### How this PR fixes the problem?
`client.command('normal! ${command}')` breaks insert mode paste.
This PR fixs it from removing an insert mode command.


### Check lists (check `x` in `[ ]` of list items)

- [x] Coding style (if any code was modified)
- [x] Confirmed
  - OS: OSX
  - `nvim` version: 0.0.22


