### PR TITLE
Remove '$' from argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Then you need to put the popup tooltip UI on your NyaoVim interface.  Please ope
 Please add `<popup-tooltip>` tag under `<neovim-editor>` tag as below
 
 ```html
-<neovim-editor id="nyaovim-editor" argv$="[[argv]]"></neovim-editor>
+<neovim-editor id="nyaovim-editor" argv="[[argv]]"></neovim-editor>
 <popup-tooltip editor="[[editor]]"></popup-tooltip>
 ```
 


### PR DESCRIPTION
### What was a problem?

One of the examples still references an incorrect attribute binding (Related: https://github.com/rhysd/NyaoVim/issues/65)

### How this PR fixes the problem?

Updated the example to not have '$'

### Check lists (check `x` in `[ ]` of list items)

- [X] Coding style (if any code was modified)
- [X] Confirmed
  - OS: macOS 10.12.1
  - `nvim` version: NVIM 0.1.7

### Additional Comments (if any)

